### PR TITLE
fix (parser): disabled warnings about HTML5 tags

### DIFF
--- a/src/hypeJunction/Parser.php
+++ b/src/hypeJunction/Parser.php
@@ -347,6 +347,9 @@ class Parser {
 			return false;
 		}
 		$doc = new DOMDocument();
+		
+		libxml_use_internal_errors(true);
+		
 		if (is_callable('mb_convert_encoding')) {
 			$doc->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'));
 		} else {
@@ -355,6 +358,9 @@ class Parser {
 		if (!$doc->documentURI) {
 			$doc->documentURI = $url;
 		}
+		
+		libxml_clear_errors();
+		
 		return $doc;
 	}
 


### PR DESCRIPTION
DOMDocument doesn't support HTML5 tags. 

During parse we've get these errors:

> PHP Warning "DOMDocument::loadHTML(): Tag use invalid in Entity, line: 371" in file \www\elgg\mod\hypeScraper\vendor\hypejunction\http-parser\src\hypeJunction\Parser.php (line 351)
> PHP Warning "DOMDocument::loadHTML(): Tag svg invalid in Entity, line: 371" in file \www\elgg\mod\hypeScraper\vendor\hypejunction\http-parser\src\hypeJunction\Parser.php (line 351)
> ....

Stackoverflow Threads:
[http://stackoverflow.com/questions/9149180/domdocumentloadhtml-error](http://stackoverflow.com/questions/9149180/domdocumentloadhtml-error)
[http://stackoverflow.com/questions/6090667/php-domdocument-errors-warnings-on-html5-tags](http://stackoverflow.com/questions/6090667/php-domdocument-errors-warnings-on-html5-tags)
[http://stackoverflow.com/questions/11819603/dom-loadhtml-doesnt-work-properly-on-a-server](http://stackoverflow.com/questions/11819603/dom-loadhtml-doesnt-work-properly-on-a-server)